### PR TITLE
Fix potential vulnerability in comapt.secrets

### DIFF
--- a/aioice/compat.py
+++ b/aioice/compat.py
@@ -8,9 +8,12 @@ except ImportError:
     secrets = None
 
 
+_system_random = random.SystemRandom()
+
+
 class CompatSecrets:
     def choice(self, sequence):
-        return random.choice(sequence)
+        return _system_random.choice(sequence)
 
     def randbits(self, k):
         assert k == 64


### PR DESCRIPTION
* the CompatSecrets.choice method is used by random_string to generate tokens some of which probably should come from a cryptographically secure random number generator, the previous use of random.choice did not fulfil this requirement.

* I looked at the CPython source code, and [at least since 2010 `random.SystemRandom`](https://github.com/python/cpython/blob/c585eecfb0384a9c6b560477c1f04c43b55cc8e3/Lib/random.py#L617) is a class derived from `random.Random` that only overwrites the actual methods retrieving the randomness by calls to urandom, so SystemRandom.choice will be available on any remotely recent CPython version, if it has support for `os.urandom`.