### PR TITLE
ice: prevent infinite loop on unclean shutdown

### DIFF
--- a/aioice/ice.py
+++ b/aioice/ice.py
@@ -754,6 +754,7 @@ class Connection:
                     failures += 1
                 if failures >= CONSENT_FAILURES:
                     self.__log_info('Consent to send expired')
+                    self._query_consent_handle = None
                     return await self.close()
 
     def request_received(self, message, addr, protocol, raw_data):


### PR DESCRIPTION
I ran into an issue where I'd exceed the stack depth if I opened a data-only connection from a web client and then leave the page (e.g. by refreshing it.)  This patch represents my attempt to solve the problem.

I still haven't discovered how to catch disconnections, but at least with this patch I don't get double-faults once the connection times out.